### PR TITLE
fix: handle str/enum deserialization for LightGBM params and sync lin…

### DIFF
--- a/src/scxpand/lightgbm/run_lightgbm_.py
+++ b/src/scxpand/lightgbm/run_lightgbm_.py
@@ -18,7 +18,7 @@ from scxpand.data_util.transforms import (
 )
 from scxpand.lightgbm.lightgbm_params import LightGBMParams
 from scxpand.util.classes import ModelType
-from scxpand.util.general_util import save_params, set_seed
+from scxpand.util.general_util import enum_value, save_params, set_seed
 from scxpand.util.logger import get_logger
 from scxpand.util.model_constants import SKLEARN_MODEL_FILE
 
@@ -163,8 +163,8 @@ def run_lightgbm_training(
         bagging_fraction=prm.bagging_fraction,
         min_split_gain=prm.min_split_gain,
         min_child_weight=prm.min_child_weight,
-        boosting_type=prm.boosting_type.value,
-        objective=prm.objective.value,
+        boosting_type=enum_value(prm.boosting_type),
+        objective=enum_value(prm.objective),
         verbose=prm.verbose,
     )
     model.fit(

--- a/src/scxpand/linear/linear_params.py
+++ b/src/scxpand/linear/linear_params.py
@@ -104,7 +104,6 @@ class LinearClassifierParam(BaseParams):
             init_learning_rate=self.init_learning_rate,
         )
 
-    @classmethod
-    def get_model_type(cls) -> ModelType:
+    def get_model_type(self) -> ModelType:
         """Return the model type identifier for this parameter class."""
-        return cls().model_type
+        return self.model_type

--- a/src/scxpand/main.py
+++ b/src/scxpand/main.py
@@ -99,6 +99,11 @@ def train(
         param_class=model_spec.param_class, config_path=config_path, **kwargs
     )
 
+    # For linear models (logistic/svm), the params class is shared and defaults to logistic.
+    # Sync the CLI model_type into prm so the correct SGD loss function is selected.
+    if hasattr(prm, "model_type") and prm.model_type != model_type_enum:
+        prm.model_type = model_type_enum
+
     # Run training
     call_training_function(
         model_type=model_type_enum,

--- a/src/scxpand/util/general_util.py
+++ b/src/scxpand/util/general_util.py
@@ -43,6 +43,15 @@ def convert_enums_to_values(obj: Any) -> Any:
         return obj
 
 
+def enum_value(val: Any) -> Any:
+    """Return the .value of an enum, or the value itself if already a plain type.
+
+    Handles the case where a field typed as an Enum was deserialized as a plain
+    string (e.g., loaded from JSON), so callers don't need to branch on the type.
+    """
+    return val.value if isinstance(val, Enum) else val
+
+
 def save_json_data(data: dict[str, Any], save_path: Path | str):
     """Save arbitrary dictionary data to a JSON file.
 

--- a/src/scxpand/util/general_util.py
+++ b/src/scxpand/util/general_util.py
@@ -96,7 +96,7 @@ def save_params(params: BaseParams, save_dir: Path | str):
     # Get model type from parameter object
     try:
         model_type = params.get_model_type()
-        save_model_type(model_type.value, save_dir)
+        save_model_type(enum_value(model_type), save_dir)
     except AttributeError:
         logger.warning(
             f"Parameter object {type(params)} does not have get_model_type method"


### PR DESCRIPTION
…ear model_type from CLI

- Add enum_value() util to safely extract .value from enums or pass strings through (backwards-compatible)
- Use enum_value() for boosting_type and objective in run_lightgbm_.py so JSON-deserialized plain strings don't crash
- Fix get_model_type() in LinearClassifierParam to be an instance method returning self.model_type
- Sync CLI model_type into prm in main.py for linear models where param class defaults to logistic